### PR TITLE
Add logic to accept null vector as OK

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Nagios plugin for alerting on Prometheus query results.
                      Options and option values must be passed separately.
                      e.g. -C --connect-timeout -C 10 -C --cacert -C /path/to/ca.crt
     -O               Accept NaN as an "OK" result.
+    -E               Accept an empty vector (null) as an "OK" result.
     -i               Print the extra metric information into the Nagios message.
     -p               Add perfdata to check output.
 

--- a/src/check_prometheus_metric.sh
+++ b/src/check_prometheus_metric.sh
@@ -91,7 +91,6 @@ function process_command_line {
       E)        NULL_OK="true"
                 ;;
 
-
       i)        NAGIOS_INFO="true"
                 ;;
 

--- a/src/check_prometheus_metric.sh
+++ b/src/check_prometheus_metric.sh
@@ -7,6 +7,7 @@
 CURL_OPTS=()
 COMPARISON_METHOD=ge
 NAN_OK="false"
+NULL_OK="false"
 NAGIOS_INFO="false"
 PERFDATA="false"
 PROMETHEUS_QUERY_TYPE=""
@@ -47,7 +48,7 @@ function check_dependencies() {
 
 function process_command_line {
 
-  while getopts ':H:q:w:c:m:n:C:Oipt:' OPT "$@"
+  while getopts ':H:q:w:c:m:n:C:OEipt:' OPT "$@"
   do
     case ${OPT} in
       H)        PROMETHEUS_SERVER="$OPTARG" ;;
@@ -83,8 +84,13 @@ function process_command_line {
 
       C)        CURL_OPTS+=("${OPTARG}")
                 ;;
+
       O)        NAN_OK="true"
                 ;;
+
+      E)        NULL_OK="true"
+                ;;
+
 
       i)        NAGIOS_INFO="true"
                 ;;
@@ -310,6 +316,9 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
       if [[ "${NAN_OK}" = "true" && "${PROMETHEUS_RESULT}" = "NaN" ]]; then
         NAGIOS_STATUS=OK
         NAGIOS_SHORT_TEXT="${METRIC_NAME} is ${PROMETHEUS_RESULT}"
+      elif [[ "${NULL_OK}" = "true" && "${PROMETHEUS_RESULT}" = "null" ]]; then
+        NAGIOS_STATUS=OK
+        NAGIOS_SHORT_TEXT="${METRIC_NAME} is empty"
       else
         NAGIOS_SHORT_TEXT="unable to parse prometheus response"
         NAGIOS_LONG_TEXT="${METRIC_NAME} is ${PROMETHEUS_RESULT}"

--- a/src/usage.bash
+++ b/src/usage.bash
@@ -20,6 +20,7 @@ function usage() {
                      Options and option values must be passed separately.
                      e.g. -C --connect-timeout -C 10 -C --cacert -C /path/to/ca.crt
     -O               Accept NaN as an "OK" result.
+    -E               Accept an empty vector (null) as an "OK" result.
     -i               Print the extra metric information into the Nagios message.
     -p               Add perfdata to check output.
 

--- a/tests/null.bats
+++ b/tests/null.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+PROMETHEUS_SERVER=http://localhost:${PROMETHEUS_PORT}
+
+load test_utils
+
+@test "--- ${BATS_TEST_FILENAME} ---" {
+  true
+}
+# Base-case
+@test "Test -q 1 -w 2 -c 3" {
+  OUTPUT="$(test_parameters '-q 1 -w 2 -c 3')"
+  [ "${OUTPUT}" == "OK - tc is 1" ]
+}
+@test "Test -q 1 -w 2 -c 3 -O" {
+  OUTPUT="$(test_parameters '-q 1 -w 2 -c 3 -O')"
+  [ "${OUTPUT}" == "OK - tc is 1" ]
+}
+
+# Server returns: {"status":"success","data":{"resultType":"vector","result":[]}}
+@test "Test -q topk(1,hopefully_this_never_matches) -w 2 -c 3" {
+  OUTPUT="$(test_parameters '-q topk(1,hopefully_this_never_matches) -w 2 -c 3')"
+  [ "${OUTPUT}" == "UNKNOWN - unable to parse prometheus response" ]
+}
+@test "Test -q topk(1,hopefully_this_never_matches) -w 2 -c 3 -O" {
+  OUTPUT="$(test_parameters '-q topk(1,hopefully_this_never_matches) -w 2 -c 3 -O')"
+  [ "${OUTPUT}" == "OK - tc is empty" ]
+}


### PR DESCRIPTION
I was trying to use check_prometheus_metric to check for filesystems that would fill in the next 24 hours given the 10m deriv.  I have to use a test against > 0 because negative values indicate that filesystem usage is shrinking.  If no filesystems are growing I get an empty result.  I couldn't figure out how to deal with this given the available options. Nor could I figure out how to get prometheus to always return a value. For reference here is the query I was using: 
```
 ./check_prometheus_metric.sh -H http://127.0.0.1:9090/prometheus -q 'floor(min by (mountpoint) (bottomk(1,(node_filesystem_avail_bytes{instance="x",fstype!~"tmpfs",fstype!~"fuse.*"}/(deriv(node_filesystem_avail_bytes[10m])*(-3600)))>0)))' -w 24 -c 4 -n HoursTillFull -m lt -i 
```