### PR TITLE
Add null_ok flag

### DIFF
--- a/src/check_prometheus_metric.sh
+++ b/src/check_prometheus_metric.sh
@@ -7,6 +7,7 @@
 CURL_OPTS=()
 COMPARISON_METHOD=ge
 NAN_OK="false"
+NULL_OK="false"
 NAGIOS_INFO="false"
 PERFDATA="false"
 PROMETHEUS_QUERY_TYPE=""
@@ -47,7 +48,7 @@ function check_dependencies() {
 
 function process_command_line {
 
-  while getopts ':H:q:w:c:m:n:C:Oipt:' OPT "$@"
+  while getopts ':H:q:w:c:m:n:C:O0ipt:' OPT "$@"
   do
     case ${OPT} in
       H)        PROMETHEUS_SERVER="$OPTARG" ;;
@@ -83,7 +84,11 @@ function process_command_line {
 
       C)        CURL_OPTS+=("${OPTARG}")
                 ;;
+
       O)        NAN_OK="true"
+                ;;
+
+      0)        NULL_OK="true"
                 ;;
 
       i)        NAGIOS_INFO="true"
@@ -308,6 +313,9 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
       fi
     else
       if [[ "${NAN_OK}" = "true" && "${PROMETHEUS_RESULT}" = "NaN" ]]; then
+        NAGIOS_STATUS=OK
+        NAGIOS_SHORT_TEXT="${METRIC_NAME} is ${PROMETHEUS_RESULT}"
+      elif [[ "${NULL_OK}" = "true" && "${PROMETHEUS_RESULT}" = "null" ]]; then
         NAGIOS_STATUS=OK
         NAGIOS_SHORT_TEXT="${METRIC_NAME} is ${PROMETHEUS_RESULT}"
       else

--- a/src/usage.bash
+++ b/src/usage.bash
@@ -20,6 +20,7 @@ function usage() {
                      Options and option values must be passed separately.
                      e.g. -C --connect-timeout -C 10 -C --cacert -C /path/to/ca.crt
     -O               Accept NaN as an "OK" result.
+    -0               Accept null as an "OK" result.
     -i               Print the extra metric information into the Nagios message.
     -p               Add perfdata to check output.
 


### PR DESCRIPTION
When creating checks we ran into issues where filtered queries would produce null when no alarming instances were passing the filter. While this could also be remedied in the query it is nicer to just be able to accept null as an OK value.