### PR TITLE
Update README.md - more clear install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ object CheckCommand "check_prometheus_metric" {
 ```
 GIT_REPO=https://github.com/magenta-aps/check_prometheus_metric
 VERSION=$(curl -sL -H "Accept: application/json" ${GIT_REPO}/releases/latest | jq -r .tag_name)
-curl -sL -o . ${GIT_REPO}/releases/download/${VERSION}/check_prometheus_metric.sh
+curl -sL -O ${GIT_REPO}/releases/download/${VERSION}/check_prometheus_metric.sh
 chmod +x check_prometheus_metric.sh
 sudo mv check_prometheus_metric.sh /usr/lib/nagios/plugins/check_prometheus_metric
 ```


### PR DESCRIPTION
I suggest using "curl -sL -O examble.com" instead of "curl -sL -o . example.com". 

When we use "-o .", curl exists with error: "Warning: Failed to create the file .: Is a directory; curl: (23) Failure writing output to destination" 
While -O option works fine and does what we want (from man curl): 
-O, --remote-name - Write output to a local file named like the remote file we get. (Only the file part of the remote file is used, the path is cut off.) The file will be saved in the current working directory.